### PR TITLE
Added security tools and fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,20 @@
 
 - [warp](https://github.com/NethermindEth/warp) - Solidity to cairo transpiler
 
-#### Audit
+#### Security
+
+- [Amarna](https://github.com/crytic/amarna) - Amarna is a static-analyzer and linter for the Cairo programming language.
+
+- [Medjai] https://github.com/Veridise/Medjai - Medjai is an open-sourced general framework for reasoning about  Cairo programs based on symbolic execution. Note: Medjai is still under active development.
+
+- [Horus] https://github.com/NethermindEth/horus-checker - Horus, a formal verification tool for StarkNet smart contracts.
+
+- [Tayt] https://github.com/crytic/tayt - Tayt is a StarkNet smart contract fuzzer.
+
+- [Cairo-Fuzzer] https://github.com/FuzzingLabs/cairo-fuzzer - Cairo-fuzzer is a tool designed by Fuzzing Labs, for smart contract developers to test the security. It can be used as an independent tool or as a library.
+
+- [Open-Zeppelin-Contract-Wizard-for-Cairo] https://wizard.openzeppelin.com/cairo - OpenZeppelin's Cairo Contracts Wizard is a tool that gets developers a headstart when building smart contracts. Developers can use templates to build ERC20, ERC721, and custom tokens with the interactive menu components, all the while watching the code take shape. All code generated is available for download or to copy into existing projects.
+
 
 ## Editor Plugins
 

--- a/README.md
+++ b/README.md
@@ -214,15 +214,15 @@
 
 - [Amarna](https://github.com/crytic/amarna) - Amarna is a static-analyzer and linter for the Cairo programming language.
 
-- [Medjai] (https://github.com/Veridise/Medjai) - Medjai is an open-sourced general framework for reasoning about  Cairo programs based on symbolic execution. Note: Medjai is still under active development.
+- [Medjai](https://github.com/Veridise/Medjai) - Medjai is an open-sourced general framework for reasoning about  Cairo programs based on symbolic execution. Note: Medjai is still under active development.
 
-- [Horus] (https://github.com/NethermindEth/horus-checker) - Horus, a formal verification tool for StarkNet smart contracts.
+- [Horus](https://github.com/NethermindEth/horus-checker) - Horus, a formal verification tool for StarkNet smart contracts.
 
-- [Tayt] (https://github.com/crytic/tayt) - Tayt is a StarkNet smart contract fuzzer.
+- [Tayt](https://github.com/crytic/tayt) - Tayt is a StarkNet smart contract fuzzer.
 
-- [Cairo-Fuzzer] (https://github.com/FuzzingLabs/cairo-fuzzer) - Cairo-fuzzer is a tool designed by Fuzzing Labs, for smart contract developers to test the security. It can be used as an independent tool or as a library.
+- [Cairo-Fuzzer](https://github.com/FuzzingLabs/cairo-fuzzer) - Cairo-fuzzer is a tool designed by Fuzzing Labs, for smart contract developers to test the security. It can be used as an independent tool or as a library.
 
-- [Open-Zeppelin-Contract-Wizard-for-Cairo] (https://wizard.openzeppelin.com/cairo) - OpenZeppelin's Cairo Contracts Wizard is a tool that gets developers a headstart when building smart contracts. Developers can use templates to build ERC20, ERC721, and custom tokens with the interactive menu components, all the while watching the code take shape. All code generated is available for download or to copy into existing projects.
+- [Open-Zeppelin-Contract-Wizard-for-Cairo](https://wizard.openzeppelin.com/cairo) - OpenZeppelin's Cairo Contracts Wizard is a tool that gets developers a headstart when building smart contracts. Developers can use templates to build ERC20, ERC721, and custom tokens with the interactive menu components, all the while watching the code take shape. All code generated is available for download or to copy into existing projects.
 
 
 ## Editor Plugins

--- a/README.md
+++ b/README.md
@@ -213,15 +213,10 @@
 #### Security
 
 - [Amarna](https://github.com/crytic/amarna) - Amarna is a static-analyzer and linter for the Cairo programming language.
-
 - [Medjai](https://github.com/Veridise/Medjai) - Medjai is an open-sourced general framework for reasoning about  Cairo programs based on symbolic execution. Note: Medjai is still under active development.
-
 - [Horus](https://github.com/NethermindEth/horus-checker) - Horus, a formal verification tool for StarkNet smart contracts.
-
 - [Tayt](https://github.com/crytic/tayt) - Tayt is a StarkNet smart contract fuzzer.
-
 - [Cairo-Fuzzer](https://github.com/FuzzingLabs/cairo-fuzzer) - Cairo-fuzzer is a tool designed by Fuzzing Labs, for smart contract developers to test the security. It can be used as an independent tool or as a library.
-
 - [Open-Zeppelin-Contract-Wizard-for-Cairo](https://wizard.openzeppelin.com/cairo) - OpenZeppelin's Cairo Contracts Wizard is a tool that gets developers a headstart when building smart contracts. Developers can use templates to build ERC20, ERC721, and custom tokens with the interactive menu components, all the while watching the code take shape. All code generated is available for download or to copy into existing projects.
 
 

--- a/README.md
+++ b/README.md
@@ -214,15 +214,15 @@
 
 - [Amarna](https://github.com/crytic/amarna) - Amarna is a static-analyzer and linter for the Cairo programming language.
 
-- [Medjai] https://github.com/Veridise/Medjai - Medjai is an open-sourced general framework for reasoning about  Cairo programs based on symbolic execution. Note: Medjai is still under active development.
+- [Medjai] (https://github.com/Veridise/Medjai) - Medjai is an open-sourced general framework for reasoning about  Cairo programs based on symbolic execution. Note: Medjai is still under active development.
 
-- [Horus] https://github.com/NethermindEth/horus-checker - Horus, a formal verification tool for StarkNet smart contracts.
+- [Horus] (https://github.com/NethermindEth/horus-checker) - Horus, a formal verification tool for StarkNet smart contracts.
 
-- [Tayt] https://github.com/crytic/tayt - Tayt is a StarkNet smart contract fuzzer.
+- [Tayt] (https://github.com/crytic/tayt) - Tayt is a StarkNet smart contract fuzzer.
 
-- [Cairo-Fuzzer] https://github.com/FuzzingLabs/cairo-fuzzer - Cairo-fuzzer is a tool designed by Fuzzing Labs, for smart contract developers to test the security. It can be used as an independent tool or as a library.
+- [Cairo-Fuzzer] (https://github.com/FuzzingLabs/cairo-fuzzer) - Cairo-fuzzer is a tool designed by Fuzzing Labs, for smart contract developers to test the security. It can be used as an independent tool or as a library.
 
-- [Open-Zeppelin-Contract-Wizard-for-Cairo] https://wizard.openzeppelin.com/cairo - OpenZeppelin's Cairo Contracts Wizard is a tool that gets developers a headstart when building smart contracts. Developers can use templates to build ERC20, ERC721, and custom tokens with the interactive menu components, all the while watching the code take shape. All code generated is available for download or to copy into existing projects.
+- [Open-Zeppelin-Contract-Wizard-for-Cairo] (https://wizard.openzeppelin.com/cairo) - OpenZeppelin's Cairo Contracts Wizard is a tool that gets developers a headstart when building smart contracts. Developers can use templates to build ERC20, ERC721, and custom tokens with the interactive menu components, all the while watching the code take shape. All code generated is available for download or to copy into existing projects.
 
 
 ## Editor Plugins

--- a/README.md
+++ b/README.md
@@ -208,14 +208,14 @@
 
 #### Utility
 
-- [warp](https://github.com/NethermindEth/warp) - Solidity to cairo transpiler
+- [warp](https://github.com/NethermindEth/warp) - Solidity to Cairo transpiler
 
 #### Security
 
 - [Amarna](https://github.com/crytic/amarna) - Amarna is a static-analyzer and linter for the Cairo programming language.
 - [Medjai](https://github.com/Veridise/Medjai) - Medjai is an open-sourced general framework for reasoning about  Cairo programs based on symbolic execution. Note: Medjai is still under active development.
-- [Horus](https://github.com/NethermindEth/horus-checker) - Horus, a formal verification tool for StarkNet smart contracts.
-- [Tayt](https://github.com/crytic/tayt) - Tayt is a StarkNet smart contract fuzzer.
+- [Horus](https://github.com/NethermindEth/horus-checker) - Horus, a formal verification tool for Cairo smart contracts.
+- [Tayt](https://github.com/crytic/tayt) - Tayt is a Cairo smart contract fuzzer.
 - [Cairo-Fuzzer](https://github.com/FuzzingLabs/cairo-fuzzer) - Cairo-fuzzer is a tool designed by Fuzzing Labs, for smart contract developers to test the security. It can be used as an independent tool or as a library.
 - [Open-Zeppelin-Contract-Wizard-for-Cairo](https://wizard.openzeppelin.com/cairo) - OpenZeppelin's Cairo Contracts Wizard is a tool that gets developers a headstart when building smart contracts. Developers can use templates to build ERC20, ERC721, and custom tokens with the interactive menu components, all the while watching the code take shape. All code generated is available for download or to copy into existing projects.
 


### PR DESCRIPTION
[Please describe your pull request here]

## Checklist

- [x] The URL is not already present in the list (check with CTRL/CMD+F in the
      raw markdown file).
- [x] Each description starts with an uppercase character and ends with a
      period.<br>Example: `cairo - The Cairo programming language.`
- [x] Drop all `A` / `An` prefixes at the start of the description.
- [x] Avoid using the word `StarkNet` in the description.
